### PR TITLE
Fix error with token acquisition is previous stored token is expired.

### DIFF
--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -1,0 +1,15 @@
+name: Publish
+on: [workflow_dispatch]
+
+jobs:
+    build:
+      name: Publish
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v1
+        - name: Publish
+          env:
+            APIKEY: ${{ secrets.PS_GALLERY_KEY }}
+            TMPDIR: ${{ runner.temp }}
+          run: .\Publish.ps1
+          shell: pwsh

--- a/Publish.ps1
+++ b/Publish.ps1
@@ -1,0 +1,18 @@
+# Create a temporary directory
+$TempDir = Join-Path -Path $env:TMPDIR -ChildPath "Sherweb-API"
+New-Item -Path $TempDir -ItemType Directory -Force
+
+# Copy only the files you need
+Copy-Item -Path "$PSScriptRoot\docs" -Destination $TempDir
+Copy-Item -Path "$PSScriptRoot\private" -Destination $TempDir
+Copy-Item -Path "$PSScriptRoot\public" -Destination $TempDir
+Copy-Item -Path "$PSScriptRoot\*.psd1" -Destination $TempDir
+Copy-Item -Path "$PSScriptRoot\*.psm1" -Destination $TempDir
+Copy-Item -Path "$PSScriptRoot\LICENSE" -Destination $TempDir
+
+
+# Publish the module from the temp directory
+Publish-Module -Path $TempDir -NuGetApiKey $env:PS_GALLERY_KEY
+
+# Cleanup (optional - GitHub Actions cleans up after itself)
+Remove-Item -Path $TempDir -Recurse -Force

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 PowerShell Module for interacting with the Sherweb API
 
 ## Get Started
+
+Install from the PowerShell Gallery
+
+```PowerShell
+Install-Module -Name Sherweb-API
+```
+
 Run Connect-Sherweb to get connected. Provide your API credentials.
 
 Example:
@@ -12,19 +19,19 @@ Connect-Sherweb -ClientId "your-client-id" -ClientSecret $SecureClientSecret -Ga
 ```
 
 ## Available Commands
-* Connect-Sherweb
-* Get-SherwebCustomerMeterUsages
-* Get-SherwebCustomerPlatformDetails
-* Get-SherwebCustomerPlatformsConfigurations
-* Get-SherwebCustomers
-* Get-SherwebCustomerSubscriptionMeters
-* Get-SherwebCustomerSubscriptions
-* Get-SherwebCustomerSubscriptionsPricingInformation
-* Get-SherwebPlatforms
-* Get-SherwebTrackingStatus
-* New-SherwebOrderRequest
-* New-SherwebSubscriptionsAmendment
-* New-SherwebSubscriptionsCancellationRequest
-* Get-CustomerCatalogItemsPricingInformation
-* Get-SherwebCustomerCatalog
-* Get-SherwebReceivableCharges
+* [Connect-Sherweb](docs/Connect-Sherweb.md)
+* [Get-SherwebCustomerMeterUsages](docs/Get-SherwebCustomerMeterUsages.md)
+* [Get-SherwebCustomerPlatformDetails](docs/Get-SherwebCustomerPlatformDetails.md)
+* [Get-SherwebCustomerPlatformsConfigurations](docs/Get-SherwebCustomerPlatformsConfigurations.md)
+* [Get-SherwebCustomers](docs/Get-SherwebCustomers.md)
+* [Get-SherwebCustomerSubscriptionMeters](docs/Get-SherwebCustomerSubscriptionMeters.md)
+* [Get-SherwebCustomerSubscriptions](docs/Get-SherwebCustomerSubscriptions.md)
+* [Get-SherwebCustomerSubscriptionsPricingInformation](docs/Get-SherwebCustomerSubscriptionsPricingInformation.md)
+* [Get-SherwebPlatforms](docs/Get-SherwebPlatforms.md)
+* [Get-SherwebTrackingStatus](docs/Get-SherwebTrackingStatus.md)
+* [New-SherwebOrderRequest](docs/New-SherwebOrderRequest.md)
+* [New-SherwebSubscriptionsAmendment](docs/New-SherwebSubscriptionsAmendment.md)
+* [New-SherwebSubscriptionsCancellationRequest](docs/New-SherwebSubscriptionsCancellationRequest.md)
+* [Get-CustomerCatalogItemsPricingInformation](docs/Get-CustomerCatalogItemsPricingInformation.md)
+* [Get-SherwebCustomerCatalog](docs/Get-SherwebCustomerCatalog.md)
+* [Get-SherwebReceivableCharges](docs/Get-SherwebReceivableCharges.md)

--- a/Sherweb-API.psd1
+++ b/Sherweb-API.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Sherweb-API.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.1'
+ModuleVersion = '0.0.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/private/Invoke-SherwebRequest.ps1
+++ b/private/Invoke-SherwebRequest.ps1
@@ -98,7 +98,7 @@ Function Invoke-SherwebRequest {
         elseif ([DateTime]::Now -gt $script:SherwebAccessToken.Expiration) {
             $connectSplat = @{
                 ClientId     = $script:SherwebAccessToken.ClientId
-                ClientSecret = (Convert-SecureStringToPlainText -SecureString $script:SherwebAccessToken.ClientSecret)
+                ClientSecret = $script:SherwebAccessToken.ClientSecret
                 Scope        = $script:SherwebAccessToken.Scope
             }
             Connect-Sherweb @connectSplat
@@ -128,7 +128,7 @@ Function Invoke-SherwebRequest {
 
         $InvokeRestMethodParams = @{
             Headers     = @{
-                'Ocp-Apim-Subscription-Key' = (Convert-SecureStringToPlainText -SecureString $script:SherwebAccessToken.GatewaySubscriptionKey)
+                'Ocp-Apim-Subscription-Key' = $script:SherwebAccessToken.GatewaySubscriptionKey
                 'Authorization'             = "Bearer $($script:SherwebAccessToken.AccessToken)"
                 'Content-Type'              = 'application/json'
             }


### PR DESCRIPTION
Remove step that was converting the client secret to plain text before passing to Connect-Sherweb when the previous bearer token is expired. Connect-Sherweb requires a securestring. 

Bump version to 0.0.2.

Update readme.